### PR TITLE
Update ctsGE.rmd

### DIFF
--- a/vignettes/ctsGE.Rmd
+++ b/vignettes/ctsGE.Rmd
@@ -14,7 +14,9 @@ output:
  BiocStyle::html_document:
     toc: true
 ---
-
+```{r package_options, include=FALSE}
+knitr::opts_knit$set(progress = TRUE, verbose = TRUE)
+```
 
 ```{r, echo = FALSE, message = FALSE}
 library(ctsGE)


### PR DESCRIPTION
adding package option, trying to fix error: "It seems you should call rmarkdown::render() instead of knitr::knit2html() because ctsGE.Rmd appears to be an R Markdown v2 document"
