### PR TITLE
second try to update ctsGE.rmd

### DIFF
--- a/vignettes/ctsGE.Rmd
+++ b/vignettes/ctsGE.Rmd
@@ -7,16 +7,14 @@ abstract: >
 
 vignette: >
   %\VignetteIndexEntry{ctsGE Package}
-  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEngine{knitr::render_markdown}
   %\VignetteEncoding{UTF-8} 
  
 output: 
  BiocStyle::html_document:
     toc: true
 ---
-```{r package_options, include=FALSE}
-knitr::opts_knit$set(progress = TRUE, verbose = TRUE)
-```
+
 
 ```{r, echo = FALSE, message = FALSE}
 library(ctsGE)


### PR DESCRIPTION
Trying to fix error when installing :"It seems you should call rmarkdown::render() instead of knitr::knit2html() because ctsGE.Rmd appears to be an R Markdown v2 document"
