### PR TITLE
new update ctsGE

### DIFF
--- a/vignettes/ctsGE.Rmd
+++ b/vignettes/ctsGE.Rmd
@@ -7,7 +7,7 @@ abstract: >
 
 vignette: >
   %\VignetteIndexEntry{ctsGE Package}
-  %\VignetteEngine{knitr::render_markdown}
+  %\VignetteEngine{knitr}
   %\VignetteEncoding{UTF-8} 
  
 output: 


### PR DESCRIPTION
change the VignetteEngine, because when run install_github, doesn't produce vignette
